### PR TITLE
fix: init container command

### DIFF
--- a/helm-charts/gerrit/templates/gerrit.stateful-set.yaml
+++ b/helm-charts/gerrit/templates/gerrit.stateful-set.yaml
@@ -103,6 +103,14 @@ spec:
       - name: gerrit-init
         image: {{ template "registry" . }}{{ .Values.gerrit.images.gerritInit }}:{{ .Values.images.version }}
         imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+        command:
+          - python3
+          - /var/tools/gerrit-initializer
+          - -s
+          - /var/gerrit
+          - -c
+          - /var/config/gerrit-init.yaml
+          - init
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
By default it's using a wrong config file name: '/var/config/default.config.yaml'