### PR TITLE
chore: bump chart version for replica

### DIFF
--- a/helm-charts/gerrit-replica/Chart.yaml
+++ b/helm-charts/gerrit-replica/Chart.yaml
@@ -5,7 +5,7 @@ description: |-
     that it receives from a Gerrit instance via replication. It can be used to
     reduce the load on Gerrit instances.
 name: gerrit-replica
-version: 0.2.0
+version: 0.3.0
 maintainers:
 - name: Thomas Draebing
   email: thomas.draebing@sap.com


### PR DESCRIPTION
Bump the replica chart version to fix the failed Github action